### PR TITLE
Response headers are now being saved to the message (msg.headers)

### DIFF
--- a/www-request.js
+++ b/www-request.js
@@ -135,6 +135,7 @@ module.exports = function (RED) {
           }
         } else {
           msg.payload = body;
+          msg.headers = response.headers;
           if (node.metric()) {
             // Calculate request time
             var diff = process.hrtime(preRequestTimestamp);


### PR DESCRIPTION
Hey!
Great job with the module, works great for me. However, I needed also to have headers saved to the message object and it didn't do that yet.

It's only one line addition but thought you might want to have it back.
Cheers!