### PR TITLE
Add HTTP status code to the response message

### DIFF
--- a/www-request.js
+++ b/www-request.js
@@ -136,6 +136,7 @@ module.exports = function (RED) {
         } else {
           msg.payload = body;
           msg.headers = response.headers;
+          msg.statusCode = response.statusCode;
           if (node.metric()) {
             // Calculate request time
             var diff = process.hrtime(preRequestTimestamp);


### PR DESCRIPTION
Currently, the return message doesn't return the status code of the response.