### PR TITLE
Changed to proper way of signalling priority and fallback

### DIFF
--- a/www-request.js
+++ b/www-request.js
@@ -103,7 +103,7 @@ module.exports = function (RED) {
       }
 
       if (node.ret === "obj") {
-        opts.headers.accept = "application/json, text/plain";
+        opts.headers.accept = "application/json, text/plain;q=0.9, */*;q=0.8";
       }
 
       if (this.credentials && this.credentials.user) {


### PR DESCRIPTION
The proper way of supplying an ordered list of accepted media types turns out to be ascribing a quality value to each type. Also, a catch-all fallback `*/*` is provided.

Related issue: https://github.com/spawnrider/node-red-contrib-http-request/issues/12