### PR TITLE
Prevented accept header from overwriting existing value if present

### DIFF
--- a/www-request.js
+++ b/www-request.js
@@ -102,7 +102,7 @@ module.exports = function (RED) {
         }
       }
 
-      if (node.ret === "obj") {
+      if (!("accept" in opts.headers) && node.ret === "obj") {
         opts.headers.accept = "application/json, text/plain;q=0.9, */*;q=0.8";
       }
 


### PR DESCRIPTION
Due to sloppy testing on my part, the accept header would always be overridden when the node produces a JSON object. In this fix, the header in question is only written if it doesn't have a value already.

I sincerely apologise for submitting faulty code, and I hope that this hasn't caused trouble for any user.

Related issue: https://github.com/spawnrider/node-red-contrib-http-request/issues/12